### PR TITLE
chore: Remove "Sign up and log in" template

### DIFF
--- a/static/projecttemplates/index.json
+++ b/static/projecttemplates/index.json
@@ -28,15 +28,6 @@
         "category": "Basic"
     },
     {
-        "iconURL": "signup_template/signup_thumbnail.png",
-        "title": "Sign up and log in",
-        "desc": "A project with a full sign up and log in flow.",
-        "projectURL": "signup_template/signuptemplate-2-5.zip",
-        "category": "Basic",
-        "useCloudServices": true,
-        "cloudServicesTemplateURL": "signup_template/signup-app-cf.json"
-    },
-    {
         "iconURL": "task_manager_template/taskmanager.png",
         "title": "Task Manager App",
         "desc": "The final task manager app from the interactive lessons",


### PR DESCRIPTION
## What kind of change does this PR introduce?

This template is using Noodl Cloud Formation, "cloudServicesTemplateURL", this is not supported in the open source version of Noodl due to the lack of Noodl cloud hosted services.
