### PR TITLE
Fixed download button url

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -193,7 +193,7 @@ const config = {
         },
         {
           label: 'Download',
-          to: 'https://console.noodl.net/#/signup',
+          to: 'https://github.com/noodlapp/noodl/releases',
           target: '_blank',
           position: 'right',
           className: 'is-download-button',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix

## What is the current behavior?

Download button points to wrong url

## What is the new behavior?

Download button points to releases on github


